### PR TITLE
Ouch. My bad. Cluster master needs to listen for ALL fork events.

### DIFF
--- a/bin/amino-gateway
+++ b/bin/amino-gateway
@@ -58,7 +58,7 @@ if (cluster.isMaster) {
     console.error('Maintenance mode', program.maintMode ? 'on' : 'off');
   });
 
-  cluster.once('fork', function (worker) {
+  cluster.on('fork', function (worker) {
     function sendMaintMode (msg) {
       if (msg === 'maintMode') {
         worker.send('maintMode:' + (program.maintMode ? 'on' : 'off'));


### PR DESCRIPTION
I blame the food poisoning.
